### PR TITLE
Add known failures list for current Travis OS tests

### DIFF
--- a/tools/travis-ci/knownfailures-Ubuntu16.04-gcc4.8.5-x86_64-Release-3rdP.txt
+++ b/tools/travis-ci/knownfailures-Ubuntu16.04-gcc4.8.5-x86_64-Release-3rdP.txt
@@ -1,2 +1,2 @@
 NR-DEC-issue205.jp2-43-decode-md5
-NR-DEC-issue208.jp2-69-decode-md
+NR-DEC-issue208.jp2-69-decode-md5

--- a/tools/travis-ci/knownfailures-Ubuntu16.04-gcc4.8.5-x86_64-Release-3rdP.txt
+++ b/tools/travis-ci/knownfailures-Ubuntu16.04-gcc4.8.5-x86_64-Release-3rdP.txt
@@ -1,0 +1,2 @@
+NR-DEC-issue205.jp2-43-decode-md5
+NR-DEC-issue208.jp2-69-decode-md


### PR DESCRIPTION
Added two tests not covered by knownfailures-all.txt that are still not working in original OpenJPEG 2.3.1 with updated Travis gcc 5.4.0